### PR TITLE
add accuracy over time fig to experiments

### DIFF
--- a/AUD_Only_Experiment/Experiment_027.m
+++ b/AUD_Only_Experiment/Experiment_027.m
@@ -587,12 +587,16 @@ num_catch_trials = audInfo.catchtrials;
 
     %%Make Coh vs Trial graph to track progress 
     coh_vs_trial_fig = plot_coh_vs_trial(dataout, save_name);
-    
+    %%Make performance vs Trial graph to track progress 
+    interval_val=20;
+    condition=2; %set condition to auditory
+    accuracy_vs_trial_fig = plot_unisensory_accuracy_vs_trial(dataout, save_name,interval_val,condition)
     %Save all figures to Figure Directory
     saveas(fig_both, [figure_file_directory save_name '_AUD_Psyc_Func_LR.png'])
     saveas(R_fig, [figure_file_directory save_name '_AUD_Psyc_Func_R.png'])
     saveas(L_fig, [figure_file_directory save_name '_AUD_Psyc_Func_L.png'])
     saveas(coh_vs_trial_fig, [figure_file_directory save_name '_AUD_Coh_vs_Trial.png'])
+    saveas(accuracy_vs_trial_fig, [figure_file_directory save_name '_AUD_Acc_vs_Trial.png'])
     
     
     times = cell2mat(dataout(2:end,7)); %Extract the trial times 
@@ -605,7 +609,7 @@ threshold
 %%
 [n_trials_with_response,n_trials_with_reward,proportion_response_reversals_after_correct_response,proportion_response_reversals_after_incorrect_response] = response_reversal_proportions2(dataout);
 % Save all block info and add to a .mat file for later analysis  
-save([data_file_directory save_name],'dataout','Fixation_Success_Rate','AUD_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','audInfo','Total_Block_Time','eye_data_matrix', "coeff_p_values",'CIs_of_LR_fit','n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','threshold');
+save([data_file_directory save_name],'save_name','dataout','Fixation_Success_Rate','AUD_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','audInfo','Total_Block_Time','eye_data_matrix', "coeff_p_values",'CIs_of_LR_fit','n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','threshold');
 disp('Experiment Data Exported to Behavioral Data Folder')
 sca; 
 

--- a/AUD_Only_Experiment/get_accuracy_vs_trial_data.m
+++ b/AUD_Only_Experiment/get_accuracy_vs_trial_data.m
@@ -1,0 +1,47 @@
+function [accuracy_vs_trial_data_filename] = get_accuracy_vs_trial_data(dataout, save_name,interval_val)
+trial_num = cell2mat(dataout(2:end,1));
+    n_trials=size(trial_num,1);
+    completed_dataout=dataout(2:n_trials+1,:);
+    single_response_accuracy=completed_dataout(:,6);
+    trial_coherences=cell2mat(completed_dataout(:,8));
+    single_response_accuracy_values=trial_num;
+    for i_trial=1:n_trials
+        if single_response_accuracy{i_trial,1}(2) == 'e'
+            single_response_accuracy_values(i_trial,2) = 1;
+        end
+        if single_response_accuracy{i_trial,1}(2) == 'o'
+            single_response_accuracy_values(i_trial,2) = 0;
+        end
+        if single_response_accuracy{i_trial,1}(2) == '/'
+            single_response_accuracy_values(i_trial,1) = NaN;
+            single_response_accuracy_values(i_trial,2) = NaN;
+            
+        end
+    end
+    non_nan_idx=~isnan(single_response_accuracy_values);
+    single_response_accuracy_values=single_response_accuracy_values(non_nan_idx(:,1),:);
+    trial_coherences=trial_coherences(non_nan_idx(:,1),:);
+    n_responses=size(single_response_accuracy_values,1);
+    cumulative_accuracy=single_response_accuracy_values(:,1);
+    interval_accuracy=nan(floor(n_responses/interval_val),2);
+    interval_startpoint=1;
+    for i_response=1:n_responses
+        cumulative_accuracy(i_response,2)=(sum(single_response_accuracy_values(1:i_response,2))/i_response)*100;
+    end
+    for i_interval=1:floor(n_responses/interval_val)
+        interval_endpoint=i_interval*interval_val;
+        interval_accuracy(i_interval,1)=cumulative_accuracy(interval_endpoint,1);
+        interval_accuracy(i_interval,2)=sum(single_response_accuracy_values(interval_startpoint:interval_endpoint,2)/interval_val)*100;
+        interval_startpoint=interval_startpoint+interval_val;
+    end
+    remaining_trials=rem(n_responses,interval_val);
+    if remaining_trials ~= 0
+        interval_endpoint=n_responses;
+        interval_accuracy(floor(n_responses/interval_val)+1,1)=cumulative_accuracy(interval_endpoint,1);
+        interval_startpoint=n_responses-remaining_trials+1;
+        interval_accuracy(floor(n_responses/interval_val)+1,2)=sum(single_response_accuracy_values(interval_startpoint:interval_endpoint,2)/remaining_trials)*100;
+        
+    end
+    accuracy_vs_trial_data_filename=sprintf('%s_AccVsTrial',save_name);
+    save(accuracy_vs_trial_data_filename);
+    

--- a/AUD_Only_Experiment/plot_unisensory_accuracy_vs_trial.m
+++ b/AUD_Only_Experiment/plot_unisensory_accuracy_vs_trial.m
@@ -1,0 +1,37 @@
+function fig = plot_unisensory_accuracy_vs_trial(dataout, save_name,interval_val,condition)
+%plot the cumulative accuracy of responses over the course of the block to
+%visualize performance for single modality conditions (aud only or v only)
+    %condition: 1=visual, 2=auditory, 3=AV
+    [accuracy_vs_trial_data_filename] = get_accuracy_vs_trial_data(dataout, save_name,interval_val)
+    current_folder=pwd;
+    condition_list={'VIS','AUD','AV'};
+    load(sprintf('%s/%s',current_folder,accuracy_vs_trial_data_filename));
+    delete(sprintf('%s/%s.mat',current_folder,accuracy_vs_trial_data_filename));
+    fig = figure();
+    %fig.Position = [850 1240 1550 500];
+    if condition==1
+        plot(cumulative_accuracy(:,1), cumulative_accuracy(:,2),'b','LineWidth',2.5);
+
+    else
+        plot(cumulative_accuracy(:,1), cumulative_accuracy(:,2),'r','LineWidth',2.5);
+    end
+    hold on
+    plot(interval_accuracy(:,1),interval_accuracy(:,2),'g*--','LineWidth',2,'MarkerSize',10);
+    plot(cumulative_accuracy(:,1), trial_coherences*100,'k','LineWidth',1.5);
+    ax=gca;
+    ax.FontSize=19;
+    set(ax,'XTick',[0:(interval_val*2):cumulative_accuracy(n_responses,1)]);
+    ylim([0,100]);
+    xlim([0,cumulative_accuracy(n_responses,1)]);
+    legend('cumulative % accuracy','accuracy for last 10 trials', 'coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    xlabel('Trial Number');
+    ylabel('% Accuracy/Coherence');
+    title(sprintf('Performance Across %s Trials\n%s',condition_list{condition},save_name), 'Interpreter', 'none');
+    ax.FontSize=12;
+
+    legend('cumulative % accuracy','accuracy for last 10 trials', 'coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    
+
+ 
+
+end

--- a/Mixed_Modality_Experiment/Experiment_027.m
+++ b/Mixed_Modality_Experiment/Experiment_027.m
@@ -646,11 +646,14 @@ while (BreakState ~= 1) && (block_counter <= total_blocks) % each block
     %%Make Coh vs Trial graph to track progress
     coh_vs_trial_fig = plot_coh_vs_trial_modalities(AUD_dataout, VIS_dataout, save_name);
     
+    %make accuracy vs trial graph
+    accuracy_vs_trial_fig = plot_AndV_accuracy_vs_trial(dataout, save_name, interval_val)
     %Save all figures to Figure Directory
     saveas(fig_both_AUD_VIS, [figure_file_directory save_name '_Psyc_Func_LR_AV_Mixed.png'])
     saveas(R_fig_AV, [figure_file_directory save_name '_Psyc_Func_R_AV_Mixed.png'])
     saveas(L_fig_AV, [figure_file_directory save_name '_Psyc_Func_L_AV_Mixed.png'])
     saveas(coh_vs_trial_fig, [figure_file_directory save_name '_Coh_vs_Trial_AV_Mixed.png'])
+    saveas(accuracy_vs_trial_fig, [figure_file_directory save_name '_Acc_vs_Trial_AV_Mixed.png'])
     
     
     times = cell2mat(dataout(2:end,7)); %Extract the trial times
@@ -664,7 +667,7 @@ VIS_threshold
 %%
 [n_trials_with_response,n_trials_with_reward,proportion_response_reversals_after_correct_response,proportion_response_reversals_after_incorrect_response] = response_reversal_proportions_mixedmodality(dataout)
 % Save all block info and add to a .mat file for later analysis  
-save([data_file_directory save_name],'dataout','Fixation_Success_Rate','Stim_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','audInfo','dotInfo','Total_Block_Time','eye_data_matrix', 'AUD_p_values', 'VIS_p_values','n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','AUD_threshold','VIS_threshold');
+save([data_file_directory save_name],'save_name','dataout','Fixation_Success_Rate','Stim_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','audInfo','dotInfo','Total_Block_Time','eye_data_matrix', 'AUD_p_values', 'VIS_p_values','n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','AUD_threshold','VIS_threshold');
 
 disp('Experiment Data Exported to Behavioral Data Folder')
 sca; 

--- a/Mixed_Modality_Experiment/plot_AndV_accuracy_vs_trial.m
+++ b/Mixed_Modality_Experiment/plot_AndV_accuracy_vs_trial.m
@@ -1,0 +1,130 @@
+function fig = plot_AndV_accuracy_vs_trial(dataout, save_name, interval_val)
+%plot the accuracy of individual trials over the course of the block to
+%visualize staircase for blocks with interleaved aud only and vis only
+%trials (mixed modality experiment)
+    % Get the Frequencies for each coherence in each modality
+    [AUD_dataout, VIS_dataout] = modality_splitter(dataout);
+    VIS_trial_num = cell2mat(VIS_dataout(2:end,1));
+    VIS_n_trials=size(VIS_trial_num,1);
+    VIS_completed_dataout=VIS_dataout(2:VIS_n_trials+1,:);
+    VIS_single_response_accuracy=VIS_completed_dataout(:,6);
+    VIS_trial_coherences=cell2mat(VIS_completed_dataout(:,8));
+    VIS_single_response_accuracy_values=VIS_trial_num;
+    for i_trial=1:VIS_n_trials
+        if VIS_single_response_accuracy{i_trial,1}(2) == 'e'
+            VIS_single_response_accuracy_values(i_trial,2) = 1;
+        end
+        if VIS_single_response_accuracy{i_trial,1}(2) == 'o'
+            VIS_single_response_accuracy_values(i_trial,2) = 0;
+        end
+        if VIS_single_response_accuracy{i_trial,1}(2) == '/'
+            VIS_single_response_accuracy_values(i_trial,1) = NaN;
+            VIS_single_response_accuracy_values(i_trial,2) = NaN;
+            
+        end
+    end
+    VIS_non_nan_idx=~isnan(VIS_single_response_accuracy_values);
+    VIS_single_response_accuracy_values=VIS_single_response_accuracy_values(VIS_non_nan_idx(:,1),:);
+    VIS_trial_coherences=VIS_trial_coherences(VIS_non_nan_idx(:,1),:);
+    VIS_n_responses=size(VIS_single_response_accuracy_values,1);
+    VIS_cumulative_accuracy=VIS_single_response_accuracy_values(:,1);
+    VIS_interval_accuracy=nan(floor(VIS_n_responses/interval_val),2);
+    VIS_interval_startpoint=1;
+    for i_response=1:VIS_n_responses
+        VIS_cumulative_accuracy(i_response,2)=(sum(VIS_single_response_accuracy_values(1:i_response,2))/i_response)*100;
+    end
+    for i_interval=1:floor(VIS_n_responses/interval_val)
+        VIS_interval_endpoint=i_interval*interval_val;
+        VIS_interval_accuracy(i_interval,1)=VIS_cumulative_accuracy(VIS_interval_endpoint,1);
+        VIS_interval_accuracy(i_interval,2)=sum(VIS_single_response_accuracy_values(VIS_interval_startpoint:VIS_interval_endpoint,2)/interval_val)*100;
+        VIS_interval_startpoint=VIS_interval_startpoint+interval_val;
+    end
+    VIS_remaining_trials=rem(VIS_n_responses,interval_val);
+    if VIS_remaining_trials ~= 0
+        VIS_interval_endpoint=VIS_n_responses;
+        VIS_interval_accuracy(floor(VIS_n_responses/interval_val)+1,1)=VIS_cumulative_accuracy(VIS_interval_endpoint,1);
+        VIS_interval_startpoint=VIS_n_responses-VIS_remaining_trials+1;
+        VIS_interval_accuracy(floor(VIS_n_responses/interval_val)+1,2)=sum(VIS_single_response_accuracy_values(VIS_interval_startpoint:VIS_interval_endpoint,2)/VIS_remaining_trials)*100;
+        
+    end
+    AUD_trial_num = cell2mat(AUD_dataout(2:end,1));
+    AUD_n_trials=size(AUD_trial_num,1);
+    AUD_completed_dataout=AUD_dataout(2:AUD_n_trials+1,:);
+    AUD_single_response_accuracy=AUD_completed_dataout(:,6);
+    AUD_trial_coherences=cell2mat(AUD_completed_dataout(:,8));
+    AUD_single_response_accuracy_values=AUD_trial_num;
+    for i_trial=1:AUD_n_trials
+        if AUD_single_response_accuracy{i_trial,1}(2) == 'e'
+            AUD_single_response_accuracy_values(i_trial,2) = 1;
+        end
+        if AUD_single_response_accuracy{i_trial,1}(2) == 'o'
+            AUD_single_response_accuracy_values(i_trial,2) = 0;
+        end
+        if AUD_single_response_accuracy{i_trial,1}(2) == '/'
+            AUD_single_response_accuracy_values(i_trial,1) = NaN;
+            AUD_single_response_accuracy_values(i_trial,2) = NaN;
+            
+        end
+    end
+    AUD_non_nan_idx=~isnan(AUD_single_response_accuracy_values);
+    AUD_single_response_accuracy_values=AUD_single_response_accuracy_values(AUD_non_nan_idx(:,1),:);
+    AUD_trial_coherences=AUD_trial_coherences(AUD_non_nan_idx(:,1),:);
+    AUD_n_responses=size(AUD_single_response_accuracy_values,1);
+    AUD_cumulative_accuracy=AUD_single_response_accuracy_values(:,1);
+    AUD_interval_accuracy=nan(floor(AUD_n_responses/interval_val),2);
+    AUD_interval_startpoint=1;
+    for i_response=1:AUD_n_responses
+        AUD_cumulative_accuracy(i_response,2)=(sum(AUD_single_response_accuracy_values(1:i_response,2))/i_response)*100;
+    end
+    for i_interval=1:floor(AUD_n_responses/interval_val)
+        AUD_interval_endpoint=i_interval*interval_val;
+        AUD_interval_accuracy(i_interval,1)=AUD_cumulative_accuracy(AUD_interval_endpoint,1);
+        AUD_interval_accuracy(i_interval,2)=sum(AUD_single_response_accuracy_values(AUD_interval_startpoint:AUD_interval_endpoint,2)/interval_val)*100;
+        AUD_interval_startpoint=AUD_interval_startpoint+interval_val;
+    end
+    AUD_remaining_trials=rem(AUD_n_responses,interval_val);
+    if AUD_remaining_trials ~= 0
+        AUD_interval_endpoint=AUD_n_responses;
+        AUD_interval_accuracy(floor(AUD_n_responses/interval_val)+1,1)=AUD_cumulative_accuracy(AUD_interval_endpoint,1);
+        AUD_interval_startpoint=AUD_n_responses-AUD_remaining_trials+1;
+        AUD_interval_accuracy(floor(AUD_n_responses/interval_val)+1,2)=sum(AUD_single_response_accuracy_values(AUD_interval_startpoint:AUD_interval_endpoint,2)/AUD_remaining_trials)*100;
+        
+    end
+    
+    fig = figure();
+
+    %Top Plot AUD
+    subplot(2,1,1);
+    plot(AUD_cumulative_accuracy(:,1), AUD_cumulative_accuracy(:,2),'r','LineWidth',2.5);
+    hold on
+    plot(AUD_interval_accuracy(:,1),AUD_interval_accuracy(:,2),'g*--','LineWidth',2,'MarkerSize',10);
+    plot(AUD_cumulative_accuracy(:,1), AUD_trial_coherences*100,'k','LineWidth',1.5);
+    ax=gca;
+    ax.FontSize=19;
+    set(ax,'XTick',[0:(interval_val*2):AUD_cumulative_accuracy(AUD_n_responses,1)]);
+    ylim([10,100]);
+    xlim([0,AUD_cumulative_accuracy(AUD_n_responses,1)]);
+    legend('AUD cumulative % accuracy','AUD accuracy for last 10 trials', 'AUD coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    xlabel('Trial Number');
+    ylabel('% Accuracy/Coherence');
+    title(sprintf('AUD Performance Across Trials\n%s',save_name), 'Interpreter', 'none');
+    ax.FontSize=12;
+
+    %Bottom Plot VIS
+   
+    subplot(2,1,2);
+    plot(VIS_cumulative_accuracy(:,1), VIS_cumulative_accuracy(:,2),'b','LineWidth',2.5);
+    hold on
+    plot(VIS_interval_accuracy(:,1),VIS_interval_accuracy(:,2),'g*--','LineWidth',2,'MarkerSize',10);
+    plot(VIS_cumulative_accuracy(:,1), VIS_trial_coherences*100,'k','LineWidth',1.5);
+    ax=gca;
+    ax.FontSize=19;
+    set(ax,'XTick',[0:(interval_val*2):VIS_cumulative_accuracy(VIS_n_responses,1)]);
+    ylim([10,100]);
+    xlim([0,VIS_cumulative_accuracy(VIS_n_responses,1)]);
+    %legend('cumulative % accuracy','accuracy for last 10 trials', 'coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    xlabel('Trial Number');
+    ylabel('% Accuracy/Coherence');
+    title(sprintf('VIS Performance Across Trials\n%s',save_name), 'Interpreter', 'none');
+    ax.FontSize=12;
+end

--- a/VIS_Only_Experiment/Experiment_027.m
+++ b/VIS_Only_Experiment/Experiment_027.m
@@ -505,12 +505,17 @@ num_catch_trials = dotInfo.catchtrials;
     
     %%Make Coh vs Trial graph to track progress 
     coh_vs_trial_fig = plot_coh_vs_trial(dataout, save_name);
-    
+    %%Make performance vs Trial graph to track progress 
+    interval_val=20;
+    condition=1; %set condition to visual
+    accuracy_vs_trial_fig = plot_unisensory_accuracy_vs_trial(dataout, save_name,interval_val,condition)
+
     %Save all figures to Figure Directory
     saveas(fig_both, [figure_file_directory save_name '_VIS_Psyc_Func_LR.png'])
     saveas(R_fig, [figure_file_directory save_name '_VIS_Psyc_Func_R.png'])
     saveas(L_fig, [figure_file_directory save_name '_VIS_Psyc_Func_L.png'])
     saveas(coh_vs_trial_fig, [figure_file_directory save_name '_VIS_Coh_vs_Trial.png'])
+    saveas(accuracy_vs_trial_fig, [figure_file_directory save_name '_VIS_Acc_vs_Trial.png'])
     
     times = cell2mat(dataout(2:end,7)); %Extract the trial times 
     Total_Block_Time = sum(times);
@@ -522,7 +527,7 @@ threshold
 %%
 [n_trials_with_response,n_trials_with_reward,proportion_response_reversals_after_correct_response,proportion_response_reversals_after_incorrect_response] = response_reversal_proportions2_visual(dataout);
 % Save all block info and add to a .mat file for later analysis  
-save([data_file_directory save_name],'dataout','Fixation_Success_Rate','RDK_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','dotInfo','Total_Block_Time','eye_data_matrix', "coeff_p_values",'n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','threshold');
+save([data_file_directory save_name],'save_name','dataout','Fixation_Success_Rate','RDK_Success_Rate','Target_Success_Rate_Regular','Target_Success_Rate_Catch','ExpInfo','dotInfo','Total_Block_Time','eye_data_matrix', "coeff_p_values",'n_trials_with_response','n_trials_with_reward','proportion_response_reversals_after_correct_response','proportion_response_reversals_after_incorrect_response','threshold');
 disp('Experiment Data Exported to Behavioral Data Folder')
 sca; 
 

--- a/VIS_Only_Experiment/get_accuracy_vs_trial_data.m
+++ b/VIS_Only_Experiment/get_accuracy_vs_trial_data.m
@@ -1,0 +1,47 @@
+function [accuracy_vs_trial_data_filename] = get_accuracy_vs_trial_data(dataout, save_name,interval_val)
+trial_num = cell2mat(dataout(2:end,1));
+    n_trials=size(trial_num,1);
+    completed_dataout=dataout(2:n_trials+1,:);
+    single_response_accuracy=completed_dataout(:,6);
+    trial_coherences=cell2mat(completed_dataout(:,8));
+    single_response_accuracy_values=trial_num;
+    for i_trial=1:n_trials
+        if single_response_accuracy{i_trial,1}(2) == 'e'
+            single_response_accuracy_values(i_trial,2) = 1;
+        end
+        if single_response_accuracy{i_trial,1}(2) == 'o'
+            single_response_accuracy_values(i_trial,2) = 0;
+        end
+        if single_response_accuracy{i_trial,1}(2) == '/'
+            single_response_accuracy_values(i_trial,1) = NaN;
+            single_response_accuracy_values(i_trial,2) = NaN;
+            
+        end
+    end
+    non_nan_idx=~isnan(single_response_accuracy_values);
+    single_response_accuracy_values=single_response_accuracy_values(non_nan_idx(:,1),:);
+    trial_coherences=trial_coherences(non_nan_idx(:,1),:);
+    n_responses=size(single_response_accuracy_values,1);
+    cumulative_accuracy=single_response_accuracy_values(:,1);
+    interval_accuracy=nan(floor(n_responses/interval_val),2);
+    interval_startpoint=1;
+    for i_response=1:n_responses
+        cumulative_accuracy(i_response,2)=(sum(single_response_accuracy_values(1:i_response,2))/i_response)*100;
+    end
+    for i_interval=1:floor(n_responses/interval_val)
+        interval_endpoint=i_interval*interval_val;
+        interval_accuracy(i_interval,1)=cumulative_accuracy(interval_endpoint,1);
+        interval_accuracy(i_interval,2)=sum(single_response_accuracy_values(interval_startpoint:interval_endpoint,2)/interval_val)*100;
+        interval_startpoint=interval_startpoint+interval_val;
+    end
+    remaining_trials=rem(n_responses,interval_val);
+    if remaining_trials ~= 0
+        interval_endpoint=n_responses;
+        interval_accuracy(floor(n_responses/interval_val)+1,1)=cumulative_accuracy(interval_endpoint,1);
+        interval_startpoint=n_responses-remaining_trials+1;
+        interval_accuracy(floor(n_responses/interval_val)+1,2)=sum(single_response_accuracy_values(interval_startpoint:interval_endpoint,2)/remaining_trials)*100;
+        
+    end
+    accuracy_vs_trial_data_filename=sprintf('%s_AccVsTrial',save_name);
+    save(accuracy_vs_trial_data_filename);
+    

--- a/VIS_Only_Experiment/plot_unisensory_accuracy_vs_trial.m
+++ b/VIS_Only_Experiment/plot_unisensory_accuracy_vs_trial.m
@@ -1,0 +1,37 @@
+function fig = plot_unisensory_accuracy_vs_trial(dataout, save_name,interval_val,condition)
+%plot the cumulative accuracy of responses over the course of the block to
+%visualize performance for single modality conditions (aud only or v only)
+    %condition: 1=visual, 2=auditory, 3=AV
+    [accuracy_vs_trial_data_filename] = get_accuracy_vs_trial_data(dataout, save_name,interval_val)
+    current_folder=pwd;
+    condition_list={'VIS','AUD','AV'};
+    load(sprintf('%s/%s',current_folder,accuracy_vs_trial_data_filename));
+    delete(sprintf('%s/%s.mat',current_folder,accuracy_vs_trial_data_filename));
+    fig = figure();
+    %fig.Position = [850 1240 1550 500];
+    if condition==1
+        plot(cumulative_accuracy(:,1), cumulative_accuracy(:,2),'b','LineWidth',2.5);
+
+    else
+        plot(cumulative_accuracy(:,1), cumulative_accuracy(:,2),'r','LineWidth',2.5);
+    end
+    hold on
+    plot(interval_accuracy(:,1),interval_accuracy(:,2),'g*--','LineWidth',2,'MarkerSize',10);
+    plot(cumulative_accuracy(:,1), trial_coherences*100,'k','LineWidth',1.5);
+    ax=gca;
+    ax.FontSize=19;
+    set(ax,'XTick',[0:(interval_val*2):cumulative_accuracy(n_responses,1)]);
+    ylim([0,100]);
+    xlim([0,cumulative_accuracy(n_responses,1)]);
+    legend('cumulative % accuracy','accuracy for last 10 trials', 'coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    xlabel('Trial Number');
+    ylabel('% Accuracy/Coherence');
+    title(sprintf('Performance Across %s Trials\n%s',condition_list{condition},save_name), 'Interpreter', 'none');
+    ax.FontSize=12;
+
+    legend('cumulative % accuracy','accuracy for last 10 trials', 'coherence', 'Location', 'NorthEast', 'Interpreter', 'none' );
+    
+
+ 
+
+end


### PR DESCRIPTION
added a new figure that shows performance accuracy over the course of a block. functions have been added to A,V, and Mixed modality folders, and this is then called in the experiment script. I also added the variable save_name to the variables saved in the data files at the end of the block, because it would make post-hoc analysis code testing easier. 